### PR TITLE
fixed empty browserSync loading

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('runserver', () => {
     var proc = exec('python app.py', function(err, stdout, stderr){
         console.log(stdout);
         console.log(stderr);
-        error = false;
+        error = true;
     });
     if(!error){
         // No errors, run browserSync

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,31 +1,34 @@
 var gulp = require('gulp'),
     uglify = require('gulp-uglify'),
-    plumber = require('gulp-plumber'),
     browserSync = require('browser-sync');
 
 var reload = browserSync.reload;
 var exec = require('child_process').exec;
 
-// Uglify javascript
-// gulp.task('scripts', function() {
-//   gulp.src('js/*.js')
-//     .pipe(plumber())
-//     .pipe(uglify())
-//     .pipe(gulp.dest('build/js'))
-// });
-
 //Run Flask server
-gulp.task('runserver', function() {
-    var proc = exec('python app.py');
+gulp.task('runserver', () => {
+    var proc = exec('python app.py', function(err, stdout, stderr){
+        console.log(stdout);
+        // Check for errors of python script to avoid empty browserSync running.
+        if(stderr){
+            console.log(stderr);
+        }
+        else{
+            // No errors, run browserSync
+            gulp.start('browser-sync');
+        }
+    });
 });
 
-// Default task: Watch Files For Changes & Reload browser
-gulp.task('default', ['runserver'], function () {
+gulp.task('browser-sync', function() {
   browserSync({
     notify: false,
-    proxy: "127.0.0.1:5003"
+    proxy: "127.0.0.1:5003",
   });
- 
-  gulp.watch(['templates/*.*'], reload);
-
 });
+
+gulp.task('start', () => {
+    gulp.watch(['**/*.py', 'templates/**/*.html', '!env', '!node_modules'], browserSync.reload);
+});
+
+gulp.task('default', ['start', 'runserver']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,17 +7,17 @@ var exec = require('child_process').exec;
 
 //Run Flask server
 gulp.task('runserver', () => {
+    // Check for errors of python script to avoid empty browserSync running.
+    var error = false;
     var proc = exec('python app.py', function(err, stdout, stderr){
         console.log(stdout);
-        // Check for errors of python script to avoid empty browserSync running.
-        if(stderr){
-            console.log(stderr);
-        }
-        else{
-            // No errors, run browserSync
-            gulp.start('browser-sync');
-        }
+        console.log(stderr);
+        error = false;
     });
+    if(!error){
+        // No errors, run browserSync
+        gulp.start('browser-sync');
+    }
 });
 
 gulp.task('browser-sync', function() {


### PR DESCRIPTION
I use my own implementation of browserSync for flask. Initially I had a similar setup, but noticed that on app.py errors, browserSync would still run and try to proxify the Flask server, which leads to endless loading.

Hope the solution helps for those who had an issue with this.